### PR TITLE
Remove unused keyword INPUT_FORMAT:ASCII used with GEN_DATA observations

### DIFF
--- a/all_data_types/config.ert
+++ b/all_data_types/config.ert
@@ -11,7 +11,7 @@ SUMMARY FOPR
 
 GEN_KW BPR template.txt params.txt data/BPR.txt
 FIELD PORO PARAMETER poro.grdecl INIT_FILES:data/poro%d.grdecl
-GEN_DATA GEN INPUT_FORMAT:ASCII RESULT_FILE:gen%d.txt REPORT_STEPS:1
+GEN_DATA GEN RESULT_FILE:gen%d.txt REPORT_STEPS:1
 SURFACE TOP INIT_FILES:data/surf%d.irap OUTPUT_FILE:surf.irap BASE_SURFACE:data/basesurf.irap FORWARD_INIT:False
 
 -- Normally the forward model would generate the responses

--- a/snake_oil/snake_oil.ert
+++ b/snake_oil/snake_oil.ert
@@ -29,9 +29,9 @@ FORWARD_MODEL SNAKE_OIL_DIFF
 RUN_TEMPLATE templates/seed_template.txt seed.txt
 GEN_KW SNAKE_OIL_PARAM templates/snake_oil_template.txt snake_oil_params.txt parameters/snake_oil_parameters.txt
 
-GEN_DATA SNAKE_OIL_OPR_DIFF INPUT_FORMAT:ASCII RESULT_FILE:snake_oil_opr_diff_%d.txt REPORT_STEPS:199
-GEN_DATA SNAKE_OIL_WPR_DIFF INPUT_FORMAT:ASCII RESULT_FILE:snake_oil_wpr_diff_%d.txt REPORT_STEPS:199
-GEN_DATA SNAKE_OIL_GPR_DIFF INPUT_FORMAT:ASCII RESULT_FILE:snake_oil_gpr_diff_%d.txt REPORT_STEPS:199
+GEN_DATA SNAKE_OIL_OPR_DIFF RESULT_FILE:snake_oil_opr_diff_%d.txt REPORT_STEPS:199
+GEN_DATA SNAKE_OIL_WPR_DIFF RESULT_FILE:snake_oil_wpr_diff_%d.txt REPORT_STEPS:199
+GEN_DATA SNAKE_OIL_GPR_DIFF RESULT_FILE:snake_oil_gpr_diff_%d.txt REPORT_STEPS:199
 
 UPDATE_LOG_PATH log/update
 

--- a/version-2/snake_oil/snake_oil.ert
+++ b/version-2/snake_oil/snake_oil.ert
@@ -30,6 +30,6 @@ FORWARD_MODEL SNAKE_OIL_DIFF
 RUN_TEMPLATE templates/seed_template.txt seed.txt
 GEN_KW SNAKE_OIL_PARAM templates/snake_oil_template.txt snake_oil_params.txt parameters/snake_oil_parameters.txt
 
-GEN_DATA SNAKE_OIL_OPR_DIFF INPUT_FORMAT:ASCII RESULT_FILE:snake_oil_opr_diff_%d.txt REPORT_STEPS:199
-GEN_DATA SNAKE_OIL_WPR_DIFF INPUT_FORMAT:ASCII RESULT_FILE:snake_oil_wpr_diff_%d.txt REPORT_STEPS:199
-GEN_DATA SNAKE_OIL_GPR_DIFF INPUT_FORMAT:ASCII RESULT_FILE:snake_oil_gpr_diff_%d.txt REPORT_STEPS:199
+GEN_DATA SNAKE_OIL_OPR_DIFF RESULT_FILE:snake_oil_opr_diff_%d.txt REPORT_STEPS:199
+GEN_DATA SNAKE_OIL_WPR_DIFF RESULT_FILE:snake_oil_wpr_diff_%d.txt REPORT_STEPS:199
+GEN_DATA SNAKE_OIL_GPR_DIFF RESULT_FILE:snake_oil_gpr_diff_%d.txt REPORT_STEPS:199


### PR DESCRIPTION
This keyword was removed in https://github.com/equinor/ert/commit/7a1f878b3bcbdc27167258a8679a61681f3dcf84